### PR TITLE
refactor: Remove experimental feature warning suppression

### DIFF
--- a/src/jsMain/kotlin/data/Trie.kt
+++ b/src/jsMain/kotlin/data/Trie.kt
@@ -17,7 +17,6 @@
 package data
 
 
-@Suppress("experimental_feature_warning")
 value class Trie<T>(
 
     private


### PR DESCRIPTION
The commit removes the "@Suppress("experimental_feature_warning")" annotation in the Trie class. This change was made to adhere to best practices and ensure the codebase is clean and free of unnecessary suppressions.