### PR TITLE
Support displaying root name

### DIFF
--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -107,6 +107,7 @@ internal
 object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Model, ConfigurationCacheReportPage.Intent> {
 
     data class Model(
+        val rootName: String,
         val cacheAction: String,
         val requestedTasks: String,
         val documentationLink: String,
@@ -249,7 +250,9 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     private
     fun displaySummary(model: Model): View<Intent> =
         h1(
-            "${model.cacheAction.capitalize()} the configuration cache for ",
+            "${model.cacheAction.capitalize()} the configuration cache in ",
+            code(model.rootName),
+            span(" build for "),
             code(model.requestedTasks),
             br(),
             small(model.inputsSummary()),

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -40,6 +40,7 @@ external val configurationCacheProblems: () -> JsModel
 
 private
 external interface JsModel {
+    val rootName: String
     val cacheAction: String
     val requestedTasks: String
     val documentationLink: String
@@ -156,6 +157,7 @@ private
 fun reportPageModelFromJsModel(jsModel: JsModel): ConfigurationCacheReportPage.Model {
     val diagnostics = importDiagnostics(jsModel.diagnostics)
     return ConfigurationCacheReportPage.Model(
+        rootName = jsModel.rootName,
         cacheAction = jsModel.cacheAction,
         requestedTasks = jsModel.requestedTasks,
         documentationLink = jsModel.documentationLink,

--- a/src/jsTest/resources/configuration-cache-report-data.js
+++ b/src/jsTest/resources/configuration-cache-report-data.js
@@ -2,6 +2,7 @@
 function configurationCacheProblems() {
     return (
         {
+            "rootName": "sampleProject",
             "cacheAction": "storing",
             "requestedTasks": "clean build",
             "documentationLink": "https://docs.gradle.org/6.6-20200618155501+0000/userguide/configuration_cache.html",


### PR DESCRIPTION
to be able to identify to which build a given report belongs