### PR TITLE
Polish copy experience

### DIFF
--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -565,27 +565,21 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     )
 
     private
-    val invisibleBacktick: View<Intent> = span(
-        attributes { classNames("invisible-text", "text-for-copy") },
-        "`"
-    )
+    val invisibleBacktick: View<Intent> = invisibleSpanWithTextForCopy("`")
 
     private
-    val invisibleSpace: View<Intent> = span(
-        attributes { classNames("invisible-text", "text-for-copy") },
-        " "
-    )
+    val invisibleSpace: View<Intent> = invisibleSpanWithTextForCopy(" ")
 
     private
-    val invisibleOpenParen: View<Intent> = span(
-        attributes { classNames("invisible-text", "text-for-copy") },
-        "("
-    )
+    val invisibleOpenParen: View<Intent> = invisibleSpanWithTextForCopy("(")
 
     private
-    val invisibleCloseParen: View<Intent> = span(
+    val invisibleCloseParen: View<Intent> = invisibleSpanWithTextForCopy(")")
+
+    private
+    fun invisibleSpanWithTextForCopy(text: String): View<Intent> = span(
         attributes { classNames("invisible-text", "text-for-copy") },
-        ")"
+        text
     )
 
     private

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -499,7 +499,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     fun treeButtonFor(child: Tree.Focus<ProblemNode>, treeIntent: (ProblemTreeIntent) -> Intent): View<Intent> =
         when {
             child.tree.isNotEmpty() -> viewTreeButton(child, treeIntent)
-            else -> squareIcon
+            else -> leafIcon
         }
 
     private
@@ -531,9 +531,9 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     )
 
     private
-    val squareIcon = span<Intent>(
-        attributes { className("tree-icon") },
-        "■"
+    val leafIcon = span<Intent>(
+        attributes { classNames("text-backed-icon", "leaf-icon") },
+        "- "
     )
 
     private

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -349,7 +349,10 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     private
     fun countBalloon(count: Int): View<Intent> = span(
         attributes { className("group-selector__count") },
-        "$count"
+        invisibleSpace,
+        invisibleOpenParen,
+        span("$count"),
+        invisibleCloseParen
     )
 
     private
@@ -565,6 +568,24 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     val invisibleBacktick: View<Intent> = span(
         attributes { classNames("invisible-text", "text-for-copy") },
         "`"
+    )
+
+    private
+    val invisibleSpace: View<Intent> = span(
+        attributes { classNames("invisible-text", "text-for-copy") },
+        " "
+    )
+
+    private
+    val invisibleOpenParen: View<Intent> = span(
+        attributes { classNames("invisible-text", "text-for-copy") },
+        "("
+    )
+
+    private
+    val invisibleCloseParen: View<Intent> = span(
+        attributes { classNames("invisible-text", "text-for-copy") },
+        ")"
     )
 
     private

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -524,14 +524,14 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
 
     private
     val errorIcon = span<Intent>(
-        attributes { className("error-icon") },
-        "⨉"
+        attributes { classNames("text-backed-icon", "error-icon") },
+        "[error] "
     )
 
     private
     val warningIcon = span<Intent>(
-        attributes { className("warning-icon") },
-        "⚠️"
+        attributes { classNames("text-backed-icon", "warning-icon") },
+        "[warn]  " // two spaces to align with [error] prefix
     )
 
     private

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -402,7 +402,6 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
                             focus,
                             labelNode.label,
                             labelNode.docLink,
-                            prefix = squareIcon,
                             suffix = suffixForInfo(labelNode, focus)
                         )
                     }

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -506,7 +506,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     private
     fun viewTreeButton(child: Tree.Focus<ProblemNode>, treeIntent: (ProblemTreeIntent) -> Intent): View<Intent> = span(
         attributes {
-            className("tree-btn")
+            classNames("text-backed-icon", "tree-btn")
             if (child.tree.state === Tree.ViewState.Collapsed) {
                 className("collapsed")
             }
@@ -516,10 +516,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
             title("Click to ${toggleVerb(child.tree.state)}")
             onClick { treeIntent(TreeView.Intent.Toggle(child)) }
         },
-        when (child.tree.state) {
-            Tree.ViewState.Collapsed -> "› "
-            Tree.ViewState.Expanded -> "⌄ "
-        }
+        "- "
     )
 
     private

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -565,8 +565,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
             title(tooltip)
             className("copy-button")
             onClick { Intent.Copy(text) }
-        },
-        "📋"
+        }
     )
 
     private

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -499,7 +499,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     fun treeButtonFor(child: Tree.Focus<ProblemNode>, treeIntent: (ProblemTreeIntent) -> Intent): View<Intent> =
         when {
             child.tree.isNotEmpty() -> viewTreeButton(child, treeIntent)
-            else -> leafIcon
+            else -> viewLeafIcon(child)
         }
 
     private
@@ -515,8 +515,18 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
             title("Click to ${toggleVerb(child.tree.state)}")
             onClick { treeIntent(TreeView.Intent.Toggle(child)) }
         },
-        "- "
+        copyTextPrefixForTreeNode(child)
     )
+
+    private
+    fun viewLeafIcon(child: Tree.Focus<ProblemNode>): View<Intent> = span(
+        attributes { classNames("text-backed-icon", "leaf-icon") },
+        copyTextPrefixForTreeNode(child)
+    )
+
+    private
+    fun copyTextPrefixForTreeNode(child: Tree.Focus<ProblemNode>) =
+        "    ".repeat(child.depth - 1) + "- "
 
     private
     val errorIcon = span<Intent>(
@@ -528,12 +538,6 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     val warningIcon = span<Intent>(
         attributes { classNames("text-backed-icon", "warning-icon") },
         "[warn]  " // two spaces to align with [error] prefix
-    )
-
-    private
-    val leafIcon = span<Intent>(
-        attributes { classNames("text-backed-icon", "leaf-icon") },
-        "- "
     )
 
     private

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -505,7 +505,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     private
     fun viewTreeButton(child: Tree.Focus<ProblemNode>, treeIntent: (ProblemTreeIntent) -> Intent): View<Intent> = span(
         attributes {
-            classNames("text-backed-icon", "tree-btn")
+            classNames("invisible-text", "tree-btn")
             if (child.tree.state === Tree.ViewState.Collapsed) {
                 className("collapsed")
             }
@@ -520,7 +520,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
 
     private
     fun viewLeafIcon(child: Tree.Focus<ProblemNode>): View<Intent> = span(
-        attributes { classNames("text-backed-icon", "leaf-icon") },
+        attributes { classNames("invisible-text", "leaf-icon") },
         copyTextPrefixForTreeNode(child)
     )
 
@@ -530,13 +530,13 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
 
     private
     val errorIcon = span<Intent>(
-        attributes { classNames("text-backed-icon", "error-icon") },
+        attributes { classNames("invisible-text", "error-icon") },
         "[error] "
     )
 
     private
     val warningIcon = span<Intent>(
-        attributes { classNames("text-backed-icon", "warning-icon") },
+        attributes { classNames("invisible-text", "warning-icon") },
         "[warn]  " // two spaces to align with [error] prefix
     )
 
@@ -552,11 +552,19 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
 
     private
     fun reference(name: String): View<Intent> = span(
+        invisibleBacktick,
         code(name),
+        invisibleBacktick,
         copyButton(
             text = name,
             tooltip = "Copy reference to the clipboard"
         )
+    )
+
+    private
+    val invisibleBacktick: View<Intent> = span(
+        attributes { classNames("invisible-text", "text-for-copy") },
+        "`"
     )
 
     private

--- a/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
+++ b/src/jsMain/kotlin/ConfigurationCacheReportPage.kt
@@ -421,24 +421,24 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     private
     fun viewNode(node: ProblemNode): View<Intent> = when (node) {
         is ProblemNode.Project -> span(
-            span("project"),
+            span("project "),
             reference(node.path)
         )
 
         is ProblemNode.Property -> span(
-            span(node.kind),
+            span("${node.kind} "),
             reference(node.name),
             span(" of "),
             reference(node.owner)
         )
 
         is ProblemNode.SystemProperty -> span(
-            span("system property"),
+            span("system property "),
             reference(node.name),
         )
 
         is ProblemNode.Task -> span(
-            span("task"),
+            span("task "),
             reference(node.path),
             span(" of type "),
             reference(node.type)

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -412,7 +412,7 @@ fun defaultViewStateFor(isInternal: Boolean, linesCount: Int): Tree.ViewState? {
 
 private
 fun docLinkFor(it: JsDiagnostic): ProblemNode? =
-    it.documentationLink?.let { ProblemNode.Link(it, " ?") }
+    it.documentationLink?.let { ProblemNode.Link(it, "") }
 
 
 private

--- a/src/jsMain/kotlin/elmish/View.kt
+++ b/src/jsMain/kotlin/elmish/View.kt
@@ -176,6 +176,8 @@ class Attributes<I>(private val add: (Attribute<I>) -> Unit) {
 
     fun className(value: String) = add(Attribute.ClassName(value))
 
+    fun classNames(vararg values: String) = values.forEach { add(Attribute.ClassName(it)) }
+
     fun title(value: String) = add(Attribute.Named("title", value))
 
     fun href(value: String) = add(Attribute.Named("href", value))

--- a/src/jsMain/kotlin/elmish/tree/TreeView.kt
+++ b/src/jsMain/kotlin/elmish/tree/TreeView.kt
@@ -105,6 +105,8 @@ data class Tree<T>(
 
         abstract val tree: Tree<T>
 
+        abstract val depth: Int
+
         abstract fun update(f: Tree<T>.() -> Tree<T>): Tree<T>
 
         val children
@@ -120,6 +122,8 @@ data class Tree<T>(
             override val tree: Tree<T>
         ) : Focus<T>() {
 
+            override val depth: Int get() = 0
+
             override fun update(f: Tree<T>.() -> Tree<T>): Tree<T> = f(tree)
         }
 
@@ -128,6 +132,8 @@ data class Tree<T>(
             val index: Int,
             override val tree: Tree<T>
         ) : Focus<T>() {
+
+            override val depth: Int get() = parent.depth + 1
 
             override fun update(f: Tree<T>.() -> Tree<T>): Tree<T> = parent.update {
                 copy(children = children.mapAt(index, f))

--- a/src/jsMain/kotlin/elmish/tree/TreeView.kt
+++ b/src/jsMain/kotlin/elmish/tree/TreeView.kt
@@ -122,7 +122,8 @@ data class Tree<T>(
             override val tree: Tree<T>
         ) : Focus<T>() {
 
-            override val depth: Int get() = 0
+            override val depth: Int
+                get() = 0
 
             override fun update(f: Tree<T>.() -> Tree<T>): Tree<T> = f(tree)
         }
@@ -133,7 +134,8 @@ data class Tree<T>(
             override val tree: Tree<T>
         ) : Focus<T>() {
 
-            override val depth: Int get() = parent.depth + 1
+            override val depth: Int
+                get() = parent.depth + 1
 
             override fun update(f: Tree<T>.() -> Tree<T>): Tree<T> = parent.update {
                 copy(children = children.mapAt(index, f))

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -165,17 +165,17 @@ ul .tree-btn {
 }
 
 .copy-button {
+    cursor: pointer;
+    user-select: none;
     display: inline-block;
     width: 12px;
     height: 12px;
-    user-select: none;
-    cursor: pointer;
-    color: transparent;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M433.941 193.941l-51.882-51.882A48 48 0 0 0 348.118 128H320V80c0-26.51-21.49-48-48-48h-66.752C198.643 13.377 180.858 0 160 0s-38.643 13.377-45.248 32H48C21.49 32 0 53.49 0 80v288c0 26.51 21.49 48 48 48h80v48c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48V227.882a48 48 0 0 0-14.059-33.941zm-22.627 22.627a15.888 15.888 0 0 1 4.195 7.432H352v-63.509a15.88 15.88 0 0 1 7.431 4.195l51.883 51.882zM160 30c9.941 0 18 8.059 18 18s-8.059 18-18 18-18-8.059-18-18 8.059-18 18-18zM48 384c-8.822 0-16-7.178-16-16V80c0-8.822 7.178-16 16-16h66.752c6.605 18.623 24.389 32 45.248 32s38.643-13.377 45.248-32H272c8.822 0 16 7.178 16 16v48H176c-26.51 0-48 21.49-48 48v208H48zm352 96H176c-8.822 0-16-7.178-16-16V176c0-8.822 7.178-16 16-16h144v72c0 13.2 10.8 24 24 24h72v208c0 8.822-7.178 16-16 16z" fill="%23999999" stroke="%23999999"/></svg>');
+    background-size: contain;
     background-repeat: no-repeat;
-    background-size: 12px 12px;
+    vertical-align: middle;
     margin-inline-start: 0.5ex;
-    margin-inline-end: 0.5ex;
+    margin-top: -0.2em;
 }
 
 .groups {
@@ -391,7 +391,7 @@ code em, tt em {
 }
 
 code + .copy-button {
-    margin-inline-start: 0;
+    margin-inline-start: 0.2ex;
 }
 
 .java-exception {

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -71,35 +71,28 @@
     margin: 0;
 }
 
-.tree-btn.collapsed {
-    color: transparent;
-    font-size: 18px;
-    line-height: 1rem;
-    width: 20px;
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 512"><path d="M166.9 264.5l-117.8 116c-4.7 4.7-12.3 4.7-17 0l-7.1-7.1c-4.7-4.7-4.7-12.3 0-17L127.3 256 25.1 155.6c-4.7-4.7-4.7-12.3 0-17l7.1-7.1c4.7-4.7 12.3-4.7 17 0l117.8 116c4.6 4.7 4.6 12.3-.1 17z" fill="%23999999" stroke="%23999999"/></svg>');
+.tree-btn {
+    cursor: pointer;
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    background-size: contain;
     background-repeat: no-repeat;
-    background-size: 16px 16px;
-    background-position: bottom -2px left;
+    vertical-align: middle;
+    margin-top: -0.2em;
+}
+
+.tree-btn.collapsed {
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 512"><path d="M166.9 264.5l-117.8 116c-4.7 4.7-12.3 4.7-17 0l-7.1-7.1c-4.7-4.7-4.7-12.3 0-17L127.3 256 25.1 155.6c-4.7-4.7-4.7-12.3 0-17l7.1-7.1c4.7-4.7 12.3-4.7 17 0l117.8 116c4.6 4.7 4.6 12.3-.1 17z" fill="%23999999" stroke="%23999999"/></svg>');
 }
 
 .tree-btn.expanded {
-    color: transparent;
-    font-size: 18px;
-    line-height: 1rem;
-    width: 20px;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512"><path d="M119.5 326.9L3.5 209.1c-4.7-4.7-4.7-12.3 0-17l7.1-7.1c4.7-4.7 12.3-4.7 17 0L128 287.3l100.4-102.2c4.7-4.7 12.3-4.7 17 0l7.1 7.1c4.7 4.7 4.7 12.3 0 17L136.5 327c-4.7 4.6-12.3 4.6-17-.1z" fill="%23999999" stroke="%23999999"/></svg>');
-    background-repeat: no-repeat;
-    background-size: 16px 16px;
-    background-position: bottom -2px left;
 }
 
 .tree-btn, .tree-icon {
     color: #999;
     display: inline-block;
-}
-
-.tree-btn:hover {
-    cursor: pointer;
 }
 
 ul .tree-btn {

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -93,10 +93,6 @@
     background-position: bottom -2px left;
 }
 
-.tree-btn {
-    padding-right: 8px;
-}
-
 .tree-btn, .tree-icon {
     color: #999;
     display: inline-block;
@@ -107,7 +103,7 @@
 }
 
 ul .tree-btn {
-    margin-right: 4px;
+    margin-right: 3px;
 }
 
 .tree-icon {

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -169,6 +169,9 @@ ul .tree-btn {
 }
 
 .copy-button {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
     user-select: none;
     cursor: pointer;
     color: transparent;

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -167,7 +167,6 @@ ul .tree-btn {
 
 .copy-button {
     cursor: pointer;
-    user-select: none;
     display: inline-block;
     width: 12px;
     height: 12px;

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -114,7 +114,6 @@ ul .tree-btn {
 }
 
 .error-icon {
-    cursor: pointer;
     display: inline-block;
     width: 16px;
     height: 16px;
@@ -128,7 +127,6 @@ ul .tree-btn {
 }
 
 .warning-icon {
-    cursor: pointer;
     display: inline-block;
     width: 13px;
     height: 13px;

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -90,20 +90,19 @@
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512"><path d="M119.5 326.9L3.5 209.1c-4.7-4.7-4.7-12.3 0-17l7.1-7.1c4.7-4.7 12.3-4.7 17 0L128 287.3l100.4-102.2c4.7-4.7 12.3-4.7 17 0l7.1 7.1c4.7 4.7 4.7 12.3 0 17L136.5 327c-4.7 4.6-12.3 4.6-17-.1z" fill="%23999999" stroke="%23999999"/></svg>');
 }
 
-.tree-btn, .tree-icon {
-    color: #999;
-    display: inline-block;
-}
-
 ul .tree-btn {
     margin-right: 3px;
 }
 
-.tree-icon {
-    font-size: 18px;
-    line-height: 1rem;
-    padding-left: 2px;
-    margin-right: 8px;
+.leaf-icon {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 512"><path d="M32 256 H224" stroke="%23999999" stroke-width="48" stroke-linecap="round"/></svg>');
+    background-size: contain;
+    background-repeat: no-repeat;
+    vertical-align: middle;
+    margin-top: -0.2em;
 }
 
 .text-backed-icon {

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -117,36 +117,40 @@ ul .tree-btn {
     margin-right: 8px;
 }
 
-.error-icon {
-    color: transparent;
-    font-size: 18px;
-    line-height: 1rem;
-    padding-left: 2px;
-    margin-right: 8px;
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z" fill="%23FC461E" stroke="%23FC461E"/></svg>');
-    background-repeat: no-repeat;
-    background-size: 16px 16px;
-    background-position: bottom right;
+.text-backed-icon {
+    user-select: all; /* Allow the text to be selectable */
+    color: transparent; /* Hide the text */
+    text-indent: -9999px; /* Move the text out of view */
+    position: relative;
+    white-space: pre; /* Preserve trailing space in the invisible text */
 }
 
-.error-icon::selection {
-    color: transparent;
+.error-icon {
+    cursor: pointer;
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z" fill="%23FC461E" stroke="%23FC461E"/></svg>');
+    background-size: contain;
+    background-repeat: no-repeat;
+    vertical-align: middle;
+    margin-inline-start: 0.5ex;
+    margin-inline-end: 0.5ex;
+    margin-top: -0.2em;
 }
 
 .warning-icon {
-    color: transparent;
-    font-size: 18px;
-    line-height: 1rem;
-    padding-left: 2px;
-    margin-right: 0;
+    cursor: pointer;
+    display: inline-block;
+    width: 13px;
+    height: 13px;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path d="M270.2 160h35.5c3.4 0 6.1 2.8 6 6.2l-7.5 196c-.1 3.2-2.8 5.8-6 5.8h-20.5c-3.2 0-5.9-2.5-6-5.8l-7.5-196c-.1-3.4 2.6-6.2 6-6.2zM288 388c-15.5 0-28 12.5-28 28s12.5 28 28 28 28-12.5 28-28-12.5-28-28-28zm281.5 52L329.6 24c-18.4-32-64.7-32-83.2 0L6.5 440c-18.4 31.9 4.6 72 41.6 72H528c36.8 0 60-40 41.5-72zM528 480H48c-12.3 0-20-13.3-13.9-24l240-416c6.1-10.6 21.6-10.7 27.7 0l240 416c6.2 10.6-1.5 24-13.8 24z" fill="%23DEAD22" stroke="%23DEAD22"/></svg>');
+    background-size: contain;
     background-repeat: no-repeat;
-    background-size: 13px 13px;
-    background-position: bottom 3px left
-}
-
-.warning-icon::selection {
-    color: transparent;
+    vertical-align: middle;
+    margin-inline-start: 0.3ex;
+    margin-inline-end: 1.1ex;
+    margin-top: -0.1em;
 }
 
 .documentation-button {

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -105,12 +105,16 @@ ul .tree-btn {
     margin-top: -0.2em;
 }
 
-.text-backed-icon {
+.invisible-text {
     user-select: all; /* Allow the text to be selectable */
     color: transparent; /* Hide the text */
     text-indent: -9999px; /* Move the text out of view */
     position: relative;
     white-space: pre; /* Preserve meaningful whitespace in the invisible text for copying */
+}
+
+.text-for-copy {
+    display: inline-block;
 }
 
 .error-icon {

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -110,7 +110,7 @@ ul .tree-btn {
     color: transparent; /* Hide the text */
     text-indent: -9999px; /* Move the text out of view */
     position: relative;
-    white-space: pre; /* Preserve trailing space in the invisible text */
+    white-space: pre; /* Preserve meaningful whitespace in the invisible text for copying */
 }
 
 .error-icon {

--- a/src/jsMain/resources/configuration-cache-report.css
+++ b/src/jsMain/resources/configuration-cache-report.css
@@ -154,14 +154,17 @@ ul .tree-btn {
 }
 
 .documentation-button {
-    color: transparent;
-    font-size: 18px;
-    line-height: 1rem;
-    margin-left: 4px;
+    cursor: pointer;
+    display: inline-block;
+    width: 13px;
+    height: 13px;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 340c-15.464 0-28 12.536-28 28s12.536 28 28 28 28-12.536 28-28-12.536-28-28-28zm7.67-24h-16c-6.627 0-12-5.373-12-12v-.381c0-70.343 77.44-63.619 77.44-107.408 0-20.016-17.761-40.211-57.44-40.211-29.144 0-44.265 9.649-59.211 28.692-3.908 4.98-11.054 5.995-16.248 2.376l-13.134-9.15c-5.625-3.919-6.86-11.771-2.645-17.177C185.658 133.514 210.842 116 255.67 116c52.32 0 97.44 29.751 97.44 80.211 0 67.414-77.44 63.849-77.44 107.408V304c0 6.627-5.373 12-12 12zM256 40c118.621 0 216 96.075 216 216 0 119.291-96.61 216-216 216-119.244 0-216-96.562-216-216 0-119.203 96.602-216 216-216m0-32C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8z" fill="%23999999" stroke="%23999999"/></svg>');
+    background-size: contain;
     background-repeat: no-repeat;
-    background-size: 12px 12px;
-    background-position: bottom 3px left;
+    vertical-align: middle;
+    margin-inline-start: 0.5ex;
+    margin-inline-end: 0.5ex;
+    margin-top: -0.2em;
 }
 
 .documentation-button::selection {

--- a/src/jsTest/resources/configuration-cache-report-data.js
+++ b/src/jsTest/resources/configuration-cache-report-data.js
@@ -24,19 +24,23 @@ function configurationCacheProblems() {
                             "internalText": "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n\tat org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:101)\n\tat groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)\n\tat org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:263)\n\tat groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1041)\n\tat groovy.lang.Closure.call(Closure.java:405)\n\tat groovy.lang.Closure.call(Closure.java:421)\n\tat org.gradle.api.internal.AbstractTask$ClosureTaskAction.doExecute(AbstractTask.java:681)\n\tat org.gradle.api.internal.AbstractTask$ClosureTaskAction.lambda$execute$0(AbstractTask.java:668)\n\tat org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication.reapply(DefaultUserCodeApplicationContext.java:86)\n\tat org.gradle.api.internal.AbstractTask$ClosureTaskAction.execute(AbstractTask.java:668)\n\tat org.gradle.api.internal.AbstractTask$ClosureTaskAction.execute(AbstractTask.java:643)\n\tat org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$3.run(ExecuteActionsTaskExecuter.java:569)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:395)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:387)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:157)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:242)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:150)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:84)\n\tat org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)\n\tat org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:554)\n\tat org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:537)\n\tat org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.access$300(ExecuteActionsTaskExecuter.java:108)\n\tat org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$TaskExecution.executeWithPreviousOutputFiles(ExecuteActionsTaskExecuter.java:278)\n\tat org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$TaskExecution.execute(ExecuteActionsTaskExecuter.java:267)\n\tat org.gradle.internal.execution.steps.ExecuteStep.lambda$execute$1(ExecuteStep.java:33)\n\tat java.base/java.util.Optional.orElseGet(Optional.java:369)\n\tat org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:33)\n\tat org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:26)\n\tat org.gradle.internal.execution.steps.CleanupOutputsStep.execute(CleanupOutputsStep.java:67)\n\tat org.gradle.internal.execution.steps.CleanupOutputsStep.execute(CleanupOutputsStep.java:36)\n\tat org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:49)\n\tat org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:34)\n\tat org.gradle.internal.execution.steps.CancelExecutionStep.execute(CancelExecutionStep.java:43)\n\tat org.gradle.internal.execution.steps.TimeoutStep.executeWithoutTimeout(TimeoutStep.java:73)\n\tat org.gradle.internal.execution.steps.TimeoutStep.execute(TimeoutStep.java:54)\n\tat org.gradle.internal.execution.steps.CatchExceptionStep.execute(CatchExceptionStep.java:34)\n\tat org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:44)\n\tat org.gradle.internal.execution.steps.SnapshotOutputsStep.execute(SnapshotOutputsStep.java:54)\n\tat org.gradle.internal.execution.steps.SnapshotOutputsStep.execute(SnapshotOutputsStep.java:38)\n\tat org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:49)\n\tat org.gradle.internal.execution.steps.CacheStep.executeWithoutCache(CacheStep.java:159)\n\tat org.gradle.internal.execution.steps.CacheStep.execute(CacheStep.java:72)\n\tat org.gradle.internal.execution.steps.CacheStep.execute(CacheStep.java:43)\n\tat org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:44)\n\tat org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:33)\n\tat org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:38)\n\tat org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:24)\n\tat org.gradle.internal.execution.steps.SkipUpToDateStep.executeBecause(SkipUpToDateStep.java:92)\n\tat org.gradle.internal.execution.steps.SkipUpToDateStep.lambda$execute$0(SkipUpToDateStep.java:85)\n\tat java.base/java.util.Optional.map(Optional.java:265)\n\tat org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:55)\n\tat org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:39)\n\tat org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:76)\n\tat org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:37)\n\tat org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:36)\n\tat org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:26)\n\tat org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:94)\n\tat org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:49)\n\tat org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:79)\n\tat org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:53)\n\tat org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:74)\n\tat org.gradle.internal.execution.steps.SkipEmptyWorkStep.lambda$execute$2(SkipEmptyWorkStep.java:78)\n\tat java.base/java.util.Optional.orElseGet(Optional.java:369)\n\tat org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:78)\n\tat org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:34)\n\tat org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:39)\n\tat org.gradle.internal.execution.steps.LoadExecutionStateStep.execute(LoadExecutionStateStep.java:40)\n\tat org.gradle.internal.execution.steps.LoadExecutionStateStep.execute(LoadExecutionStateStep.java:28)\n\tat org.gradle.internal.execution.impl.DefaultWorkExecutor.execute(DefaultWorkExecutor.java:33)\n\tat org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:194)\n\tat org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:186)\n\tat org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter.execute(CleanupStaleOutputsExecuter.java:114)\n\tat org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)\n\tat org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:62)\n\tat org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)\n\tat org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:56)\n\tat org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)\n\tat org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)\n\tat org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)\n\tat org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor$CallableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:409)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor$CallableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:399)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:157)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:242)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:150)\n\tat org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:94)\n\tat org.gradle.internal.operations.DelegatingBuildOperationExecutor.call(DelegatingBuildOperationExecutor.java:36)\n\tat org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)\n\tat org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:41)\n\tat org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:372)\n\tat org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:359)\n\tat org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:352)\n\tat org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:338)\n\tat org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.lambda$run$0(DefaultPlanExecutor.java:127)\n\tat org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:191)\n\tat org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.executeNextNode(DefaultPlanExecutor.java:182)\n\tat org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:124)\n\tat org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)\n\tat org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\n\tat org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)\n\tat java.base/java.lang.Thread.run(Thread.java:834)\n"
                         }]
                     }
-                },{
+                }, {
                     "trace": [
                         {"kind": "SystemProperty", "name": "org.example.property"},
                         {"kind": "BuildLogic", "location": "build file 'build.gradle.kts'"}
                     ],
                     "problem": [{"text": "cannot "}, {"text": "serialize"}, {"text": " object of type "}, {"name": "java.lang.Thread"}, {"text": ", a subtype of "}, {"name": "java.lang.Thread"}, {"text": ","}, {"text": " as these are not supported with the configuration cache."}],
                     "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:disallowed_types"
-                },{
+                }, {
                     "trace": [{"kind": "BuildLogic", "location": "build file 'build.gradle'"}],
                     "input": [{"text": "system property "}, {"name": "someMessage"}],
                     "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:reading_sys_props_and_env_vars"
                 }, {
-                    "trace": [{"kind": "PropertyUsage", "name": "foo", "from": ":sub-b"}, {"kind": "Project", "path": ":sub-b"}, {"kind": "BuildLogic", "location": "build file 'sub-b/build.gradle'"}],
+                    "trace": [
+                        {"kind": "PropertyUsage", "name": "foo", "from": ":sub-b"},
+                        {"kind": "Project", "path": ":sub-b"},
+                        {"kind": "BuildLogic", "location": "build file 'sub-b/build.gradle'"}
+                    ],
                     "problem": [{"text": "Project "}, {"name": ":sub-b"}, {"text": " cannot dynamically lookup a "}, {"text": "property"}, {"text": " in the parent project "}, {"name": ":"}],
                     "error": {
                         "parts": [{
@@ -50,49 +54,29 @@ function configurationCacheProblems() {
                         }]
                     }
                 }, {
-                    "trace": [{"kind": "PropertyUsage", "name": "bar", "from": ":sub-c"}, {"kind": "Project", "path": ":sub-b"}, {"kind": "BuildLogic", "location": "build file 'sub-c/build.gradle'"}],
+                    "trace": [
+                        {"kind": "PropertyUsage", "name": "bar", "from": ":sub-c"},
+                        {"kind": "Project", "path": ":sub-b"},
+                        {"kind": "BuildLogic", "location": "build file 'sub-c/build.gradle'"}
+                    ],
                     "problem": [{"text": "Project "}, {"name": ":sub-c"}, {"text": " cannot dynamically lookup a "}, {"text": "property"}, {"text": " in the parent project "}, {"name": ":"}],
                     "error": {}
-                },{
-                  "trace": [{
-                      "kind": "TaskPath",
-                      "path": ":anotherReportedlyIncompatible"
-                  }],
-                  "incompatibleTask": [{
-                      "text": "task "
-                  }, {
-                      "name": ":anotherReportedlyIncompatible"
-                  }, {
-                      "text": " is incompatible with the configuration cache. "
-                  }, {
-                      "text": "Reason: "
-                  }, {
-                      "text": "some other reason"
-                  }, {
-                      "text": "."
-                  }],
-                  "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:task_opt_out"
-              }, {
-                  "trace": [{
-                      "kind": "TaskPath",
-                      "path": ":reportedlyIncompatible"
-                  }],
-                  "incompatibleTask": [{
-                      "text": "task "
-                  }, {
-                      "name": ":reportedlyIncompatible"
-                  }, {
-                      "text": " is incompatible with the configuration cache. "
-                  }, {
-                      "text": "Reason: "
-                  }, {
-                      "text": "declares itself as not compatible"
-                  }, {
-                      "text": "."
-                  }],
-                  "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:task_opt_out"
-              }
-          ]
+                }, {
+                    "trace": [{"kind": "TaskPath", "path": ":anotherReportedlyIncompatible"}],
+                    "incompatibleTask": [
+                        {"text": "task "}, {"name": ":anotherReportedlyIncompatible"}, {"text": " is incompatible with the configuration cache. "},
+                        {"text": "Reason: "}, {"text": "some other reason"}, {"text": "."}
+                    ],
+                    "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:task_opt_out"
+                }, {
+                    "trace": [{"kind": "TaskPath", "path": ":reportedlyIncompatible"}],
+                    "incompatibleTask": [
+                        {"text": "task "}, {"name": ":reportedlyIncompatible"}, {"text": " is incompatible with the configuration cache. "},
+                        {"text": "Reason: "}, {"text": "declares itself as not compatible"}, {"text": "."}
+                    ],
+                    "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:task_opt_out"
+                }
+            ]
         }
     );
 }

--- a/src/jsTest/resources/configuration-cache-report-data.js
+++ b/src/jsTest/resources/configuration-cache-report-data.js
@@ -71,7 +71,7 @@ function configurationCacheProblems() {
                   }, {
                       "text": "."
                   }],
-                  "documentationLink": "https://docs.gradle.org/8.9-20240604171041+0000/userguide/configuration_cache.html#config_cache:task_opt_out"
+                  "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:task_opt_out"
               }, {
                   "trace": [{
                       "kind": "TaskPath",
@@ -90,7 +90,7 @@ function configurationCacheProblems() {
                   }, {
                       "text": "."
                   }],
-                  "documentationLink": "https://docs.gradle.org/8.9-20240604171041+0000/userguide/configuration_cache.html#config_cache:task_opt_out"
+                  "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:task_opt_out"
               }
           ]
         }

--- a/src/jsTest/resources/configuration-cache-report-data.js
+++ b/src/jsTest/resources/configuration-cache-report-data.js
@@ -5,13 +5,13 @@ function configurationCacheProblems() {
             "buildName": "sampleProject",
             "cacheAction": "storing",
             "requestedTasks": "clean build",
-            "documentationLink": "https://docs.gradle.org/6.6-20200618155501+0000/userguide/configuration_cache.html",
+            "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html",
             "totalProblemCount": 4,
             "diagnostics": [
                 {
                     "trace": [{"kind": "BuildLogic", "location": "build file 'build.gradle'"}],
                     "problem": [{"text": "invocation of "}, {"name": "Task.project"}, {"text": " at execution time is unsupported."}],
-                    "documentationLink": "https://docs.gradle.org/6.6-20200618155501+0000/userguide/configuration_cache.html#use_project_during_execution",
+                    "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution",
                     "error": {
                         "summary": [{"text": "at "}, {"name": "build_44nw1yvono72kvlw7g0lm2rd7$_run_closure1$_closure2.doCall(/Users/paul/src/gradle-related/gradle/subprojects/docs/src/snippets/configurationCache/problemsGroovy/groovy/build.gradle:5)"}],
                         "parts": [{
@@ -30,11 +30,11 @@ function configurationCacheProblems() {
                         {"kind": "BuildLogic", "location": "build file 'build.gradle.kts'"}
                     ],
                     "problem": [{"text": "cannot "}, {"text": "serialize"}, {"text": " object of type "}, {"name": "java.lang.Thread"}, {"text": ", a subtype of "}, {"name": "java.lang.Thread"}, {"text": ","}, {"text": " as these are not supported with the configuration cache."}],
-                    "documentationLink": "https://docs.gradle.org/7.5-20220407191618+0000/userguide/configuration_cache.html#config_cache:requirements:disallowed_types"
+                    "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:disallowed_types"
                 },{
                     "trace": [{"kind": "BuildLogic", "location": "build file 'build.gradle'"}],
                     "input": [{"text": "system property "}, {"name": "someMessage"}],
-                    "documentationLink": "https://docs.gradle.org/6.6-20200618155501+0000/userguide/configuration_cache.html#undeclared_sys_prop_read"
+                    "documentationLink": "https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:reading_sys_props_and_env_vars"
                 }, {
                     "trace": [{"kind": "PropertyUsage", "name": "foo", "from": ":sub-b"}, {"kind": "Project", "path": ":sub-b"}, {"kind": "BuildLogic", "location": "build file 'sub-b/build.gradle'"}],
                     "problem": [{"text": "Project "}, {"name": ":sub-b"}, {"text": " cannot dynamically lookup a "}, {"text": "property"}, {"text": " in the parent project "}, {"name": ":"}],


### PR DESCRIPTION
Fixes: https://github.com/gradle/gradle/issues/29522

Given this tree in the report:
<img width="593" alt="image" src="https://github.com/gradle/configuration-cache-report/assets/2759152/3ea0686d-dfd0-4384-96dd-4788ffa7d08e">

Selecting and copying its text BEFORE resulted in the following textual clipboard contents:
```
⌄⨉Project :sub-c📋 cannot dynamically lookup a property in the parent project :📋
⌄propertybar📋 of :sub-c📋
⌄project:sub-b📋
■build file 'sub-c/build.gradle'
```

AFTER the changes, the content is the following (with meaningful indentation)
```
- [error] Project `:sub-c` cannot dynamically lookup a property in the parent project `:`
    - property `bar` of `:sub-c`
        - project `:sub-b`
            - build file 'sub-c/build.gradle'
```



