### PR TITLE
Add plugin and task locations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.js.ir.output.granularity=whole-program
 
-configuration-cache-report.version=1.16
+configuration-cache-report.version=1.17

--- a/src/jsMain/kotlin/problemReport/ProblemReportJsModel.kt
+++ b/src/jsMain/kotlin/problemReport/ProblemReportJsModel.kt
@@ -26,11 +26,13 @@ external interface JsProblemIdElement {
 }
 
 
-external interface JsFileLocation {
-    val path: String
+external interface JsLocation {
+    val path: String?
     val line: Int?
     val column: Int?
     val length: Int?
+    val pluginId: String?
+    val taskPath: String?
 }
 
 
@@ -42,7 +44,7 @@ external interface JsProblem {
     val problemDetails: Array<JsMessageFragment>?
     val contextualLabel: String?
     val solutions: Array<Array<JsMessageFragment>>?
-    val fileLocations: Array<JsFileLocation>?
+    val locations: Array<JsLocation>?
     val additionalData: Map<String, String>?
 }
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4458


To show all locations additional additional location infos for task path and plugin will be added on the gradle/gradle side.
This PR uses this additional infos to add the locations to the locations tab.