### PR TITLE
Fix some annoyances with Git configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 #
 # https://help.github.com/articles/dealing-with-line-endings/
 #
-# These are explicitly windows files and should use crlf
-*.bat           text eol=crlf
+# BAT files must use CRLF, but automatic translation with `text eol=crlf` causes "ever changed" issue with Dependabot.
+# It commits CRLF directly to the repo bypassing the content filter, while Git machinery expects it to have LF there.
+*.bat -text
 
+# Binary files
+*.jar binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,18 @@
-# Ignore Gradle project-specific cache directory
-.gradle
+# Ignore all dotfiles by default
+.*
 
-# Ignore Gradle build output directory
+# Ignore Gradle build outputs
 build
 
-# IDEA
-.idea
+# Include Git configuration
+!.gitignore
+!.gitattributes
 
-# Kotlin
-.kotlin
+# Include code style
+!.editorconfig
+
+# GitHub configuration
+!.github
+
+# Teamcity configuration
+!.teamcity


### PR DESCRIPTION
### Exclude dotfiles from Git by default

This prevents .DS_Store and other accidental dotfiles from appearing as untracked.

### Fix ever-changed `gradlew.bat` by removing crlf translation

The previous filter was operating under certain assumptions:
1. The gradlew.bat is stored with LF endings in repo
2. The content filter translates LF to CRLF during checkout because of the .gitattributes `text eol=crlf`
3. The content filter translates CRLF to LF when comparing to the commited version or committing

Dependabot updates bypassed step (3) and commited CRLF-endings directly to the repo. Now (1) doesn't hold; (2) becomes no-op, but (3) still works and compares back-translated version with LF line endings to the store version with CRLF - this obviously doesn't match, hence the always changed file in the checkout.

This commit accommodates for Dependabot's magic. Now we assume that the BAT files are stored with CRLF in the repo, and explicitly disable eol translation for those who have this enabled (otherwise they'd get LF endings because of global translation filter on Linux/macOS).

This has a downside that you have to be careful not to commit LF-ended gradlew.bat, but this shouldn't be too much of an issue, and we don't build on Windows too often anyway.