### PR TITLE
Publish the report HTML as a JVM-target resource JAR

### DIFF
--- a/.teamcity/Project.kt
+++ b/.teamcity/Project.kt
@@ -84,7 +84,7 @@ object PublishToMavenCentral : AbstractCheck({
     steps {
         gradle {
             useGradleWrapper = true
-            gradleParams = "publishMavenPublicationToRemoteRepository"
+            gradleParams = "publish"
         }
     }
 })

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 group = "org.gradle.buildtool.internal"
 description = "Configuration cache problems HTML report"
-version = "1.0"
+version = providers.gradleProperty("configuration-cache-report.version").get()
 
 repositories {
     mavenCentral()

--- a/buildSrc/src/main/kotlin/gradlebuild.configuration-cache-report.gradle.kts
+++ b/buildSrc/src/main/kotlin/gradlebuild.configuration-cache-report.gradle.kts
@@ -84,7 +84,9 @@ tasks {
     }
 
     val jar = register<Jar>("jar") {
-        from(assembleReport)
+        from(assembleReport) {
+            into("org/gradle/internal/configuration/problems")
+        }
     }
 
     assemble {

--- a/buildSrc/src/main/kotlin/gradlebuild.configuration-cache-report.gradle.kts
+++ b/buildSrc/src/main/kotlin/gradlebuild.configuration-cache-report.gradle.kts
@@ -33,6 +33,10 @@ kotlin {
         binaries.executable()
     }
 
+    // For now, the JVM target exists purely to produce the resource-only JAR that bundles the
+    // assembled report HTML. It has no Kotlin/JVM sources.
+    jvm()
+
     sourceSets {
         commonTest {
             dependencies {
@@ -83,31 +87,22 @@ tasks {
         dependsOn("jsProcessResources")
     }
 
-    val jar = register<Jar>("jar") {
+    // Pack the assembled report HTML into the JVM target's resources, so the standard
+    // jvmJar produced by the KMP plugin bundles it at the path the consumer reads from.
+    named<Copy>("jvmProcessResources") {
         from(assembleReport) {
             into("org/gradle/internal/configuration/problems")
         }
     }
 
-    assemble {
-        dependsOn(jar)
-    }
+    val jvmJar = named<Jar>("jvmJar")
 
     val verifyJar = register<VerifyJar>("verifyJar") {
-        jarFile = jar.flatMap { it.archiveFile }
+        jarFile = jvmJar.flatMap { it.archiveFile }
         receiptFile = layout.buildDirectory.file("$name/receipt.txt")
     }
 
     check {
         dependsOn(verifyJar)
     }
-}
-
-configurations.consumable("configurationCacheReport") {
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("configuration-cache-report"))
-    }
-    outgoing.artifact(tasks.named<Jar>("jar"))
 }

--- a/buildSrc/src/main/kotlin/gradlebuild.publish-libraries.gradle.kts
+++ b/buildSrc/src/main/kotlin/gradlebuild.publish-libraries.gradle.kts
@@ -17,38 +17,37 @@ val signArtifacts: Boolean = !pgpSigningKey.orNull.isNullOrEmpty()
 
 tasks.withType<Sign>().configureEach { isEnabled = signArtifacts }
 
+// The JS target is only an intermediate build input -- its webpack bundle is inlined into
+// the report HTML that the JVM jar carries -- and nothing downstream consumes the JS klib,
+// so we don't publish it. We publish the JVM module and the Kotlin Multiplatform root
+// module: the root carries the Gradle Module Metadata that redirects the bare coordinate to
+// the JVM variant, which is the documented consumption path. Disabling the JS publish tasks
+// makes `publish` (and publishToMavenLocal) do the right thing.
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    onlyIf("the JS target is not published") { !name.contains("JsPublication") }
+}
+
 signing {
     useInMemoryPgpKeys(
         providers.environmentVariable("PGP_SIGNING_KEY").orNull,
         providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
     )
     publishing.publications.configureEach {
-        if (signArtifacts) {
+        if (signArtifacts && name != "js") {
+            // We're not publishing JS artifacts, so there is no need to sign them.
             signing.sign(this)
         }
     }
 }
 
-val jar by tasks.named("jar")
-
-val sourceJar by tasks.registering(Jar::class) {
-    from(layout.files("src/main/kotlin"))
-    archiveClassifier.set("source")
-}
-
-val javadocJar by tasks.registering(Jar::class) {
-    from(layout.files("README.md"))
-    archiveClassifier.set("javadoc")
-}
-
-val moduleVersion
-    get() = providers.gradleProperty("configuration-cache-report.version").get()
+val isSnapshot
+    get() = version.toString().endsWith("-SNAPSHOT")
 
 publishing {
     repositories {
         maven {
             name = "remote"
-            val libsType = if (moduleVersion.endsWith("-SNAPSHOT")) "snapshots" else "releases"
+            val libsType = if (isSnapshot) "snapshots" else "releases"
             url = uri("$artifactoryUrl/libs-$libsType-local")
             credentials {
                 username = artifactoryUserName
@@ -56,43 +55,38 @@ publishing {
             }
         }
     }
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = "org.gradle.buildtool.internal"
-            artifactId = "configuration-cache-report"
-            version = moduleVersion
-            artifact(jar)
-            artifact(mapOf("source" to sourceJar, "classifier" to "source"))
-            artifact(mapOf("source" to javadocJar, "classifier" to "javadoc"))
 
-            pom {
-                packaging = "jar"
-                name.set("configuration-cache-report")
-                description.set(
-                    provider {
-                        require(project.description != null) { "You must set the description of published project ${project.name}" }
-                        project.description
-                    }
-                )
+    // The Kotlin Multiplatform plugin creates one publication per target (`jvm`, `js`) plus
+    // the root `kotlinMultiplatform` module. We publish the root and `jvm` (JS is skipped by
+    // the publish-task filter above). Customize the shared POM metadata across them.
+    publications.withType<MavenPublication>().configureEach {
+        val publicationName = name
+        pom {
+            name.set("${project.name} ($publicationName)")
+            description.set(
+                provider {
+                    require(project.description != null) { "You must set the description of published project ${project.name}" }
+                    project.description
+                }
+            )
+            url.set("https://github.com/gradle/configuration-cache-report")
+            licenses {
+                license {
+                    name.set("Apache-2.0")
+                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                }
+            }
+            developers {
+                developer {
+                    name.set("The Gradle team")
+                    organization.set("Gradle Technologies")
+                    organizationUrl.set("https://gradle.org")
+                }
+            }
+            scm {
+                connection.set("scm:git://github.com/gradle/configuration-cache-report.git")
+                developerConnection.set("scm:git:ssh://github.com:gradle/configuration-cache-report.git")
                 url.set("https://github.com/gradle/configuration-cache-report")
-                licenses {
-                    license {
-                        name.set("Apache-2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                developers {
-                    developer {
-                        name.set("The Gradle team")
-                        organization.set("Gradle Technologies")
-                        organizationUrl.set("https://gradle.org")
-                    }
-                }
-                scm {
-                    connection.set("scm:git://github.com/gradle/configuration-cache-report.git")
-                    developerConnection.set("scm:git:ssh://github.com:gradle/configuration-cache-report.git")
-                    url.set("https://github.com/gradle/configuration-cache-report")
-                }
             }
         }
     }

--- a/buildSrc/src/main/kotlin/gradlebuild/configcachereport/tasks/VerifyJar.kt
+++ b/buildSrc/src/main/kotlin/gradlebuild/configcachereport/tasks/VerifyJar.kt
@@ -1,7 +1,6 @@
 package gradlebuild.configcachereport.tasks
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
@@ -9,7 +8,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
+import java.util.zip.ZipFile
 
 
 @CacheableTask
@@ -22,22 +21,17 @@ abstract class VerifyJar : DefaultTask() {
     @get:OutputFile
     abstract val receiptFile: RegularFileProperty
 
-    @get:Inject
-    protected abstract val archiveOps: ArchiveOperations
-
     @TaskAction
     fun action() {
-        val jarFiles = archiveOps.zipTree(jarFile.get().asFile).files
-        require(jarFiles.isNotEmpty()) {
-            "The JAR is empty!"
+        val entries = ZipFile(jarFile.get().asFile).use { zip ->
+            zip.entries().asSequence().filter { !it.isDirectory }.map { it.name }.toList()
         }
-        require(jarFiles.size == 2) {
-            "Expected two files in the JAR, but got ${jarFiles.size}!"
-        }
-        val expectedFilenames = listOf("MANIFEST.MF", "configuration-cache-report.html")
-        val actualFilenames = jarFiles.map { it.name }
-        require(actualFilenames == expectedFilenames) {
-            "Expected file names $expectedFilenames but got $actualFilenames"
+        val expectedEntries = listOf(
+            "META-INF/MANIFEST.MF",
+            "org/gradle/internal/configuration/problems/configuration-cache-report.html",
+        )
+        require(entries.sorted() == expectedEntries.sorted()) {
+            "Expected JAR entries $expectedEntries but got $entries"
         }
         receiptFile.get().asFile.writeText("OK")
     }


### PR DESCRIPTION
Add a `jvm()` target to the multiplatform build and pack the assembled report HTML into its resources.
The standard `jvmJar` replaces the hand-rolled jar task and the custom DocsType consumable variant, so the artifact is consumable as an ordinary java-runtime library via the KMP-generated jvm variant.

Switch publishing to the standard KMP publications (root + jvm). The JS target is only a build input -- its webpack bundle is inlined into the HTML -- so it is not published. 

**This is a preliminary step to eliminate multiple sources of truth for the serialized forms of the data.** This proved to 
be problematic for people working on the report when they make changes in one place and forget to update the other side.

To align with KMP, `project.version` now derives from the `configuration-cache-report.version` property instead of the latter being set on the publication directly.

The corresponding `gradle/gradle` change is gradle/gradle#38183