### PR TITLE
Update signing configuration for PGP subkey

### DIFF
--- a/.teamcity/Project.kt
+++ b/.teamcity/Project.kt
@@ -74,6 +74,7 @@ object PublishToMavenCentral : AbstractCheck({
     description = "Publish configuration-cache-report to repo.grdev.net"
 
     params {
+        param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
         param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
         param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
         param("env.GRADLE_INTERNAL_REPO_URL", "%gradle.internal.repository.url%")

--- a/buildSrc/src/main/kotlin/gradlebuild.publish-libraries.gradle.kts
+++ b/buildSrc/src/main/kotlin/gradlebuild.publish-libraries.gradle.kts
@@ -29,6 +29,8 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
 
 signing {
     useInMemoryPgpKeys(
+        // Key ID required when signing with a subkey
+        providers.environmentVariable("PGP_SIGNING_KEY_ID").orNull,
         providers.environmentVariable("PGP_SIGNING_KEY").orNull,
         providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
     )


### PR DESCRIPTION
After the move to a signing subkey following the August 14 security incident, `useInMemoryPgpKeys` needs the key ID as its first argument — without it the signing plugin falls back to the primary key.

This adds the key ID to the `signing {}` block and makes the publishing build configuration pass it as `env.PGP_SIGNING_KEY_ID`, matching what was already done in gradle/gradle#38874, gradle/gradle-promote#382 and gradle/gradle-pom-properties#20.

The `pgpSigningKeyId` TeamCity parameter is already defined on the parent project, so no new secret is needed.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
Part of gradle/gradle-private#5321