### PR TITLE
Publish to Artifactory with a Bearer token

### DIFF
--- a/.teamcity/Project.kt
+++ b/.teamcity/Project.kt
@@ -78,8 +78,7 @@ object PublishToMavenCentral : AbstractCheck({
         param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
         param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
         param("env.GRADLE_INTERNAL_REPO_URL", "%gradle.internal.repository.url%")
-        param("env.ORG_GRADLE_PROJECT_artifactoryUserName", "%gradle.internal.repository.build-tool.publish.username%")
-        password("env.ORG_GRADLE_PROJECT_artifactoryUserPassword", "%gradle.internal.repository.build-tool.publish.password%")
+        password("env.ORG_GRADLE_PROJECT_artifactoryToken", "%gradle.internal.repository.build-tool.publish.token%")
     }
 
     steps {

--- a/buildSrc/src/main/kotlin/gradlebuild.publish-libraries.gradle.kts
+++ b/buildSrc/src/main/kotlin/gradlebuild.publish-libraries.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.authentication.http.HttpHeaderAuthentication
+
 plugins {
     `maven-publish`
     signing
@@ -6,11 +9,8 @@ plugins {
 val artifactoryUrl
     get() = providers.environmentVariable("GRADLE_INTERNAL_REPO_URL").orNull ?: ""
 
-val artifactoryUserName
-    get() = providers.gradleProperty("artifactoryUserName").orNull
-
-val artifactoryUserPassword
-    get() = providers.gradleProperty("artifactoryUserPassword").orNull
+val artifactoryToken
+    get() = providers.gradleProperty("artifactoryToken").orNull
 
 val pgpSigningKey: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY")
 val signArtifacts: Boolean = !pgpSigningKey.orNull.isNullOrEmpty()
@@ -51,9 +51,12 @@ publishing {
             name = "remote"
             val libsType = if (isSnapshot) "snapshots" else "releases"
             url = uri("$artifactoryUrl/libs-$libsType-local")
-            credentials {
-                username = artifactoryUserName
-                password = artifactoryUserPassword
+            credentials(HttpHeaderCredentials::class) {
+                name = "Authorization"
+                value = "Bearer $artifactoryToken"
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace `artifactoryUserName` / `artifactoryUserPassword` with `artifactoryToken`.
- Authenticate against `repo.grdev.net` with `Authorization: Bearer`.

Depends on https://github.com/gradle/develocity-artifactory/pull/344. Do not merge until that token is applied and copied into the TeamCity Root param `gradle.internal.repository.build-tool.publish.token`.

## Test plan
- [ ] TeamCity Root has `gradle.internal.repository.build-tool.publish.token` set
- [ ] Publish to `repo.grdev.net` succeeds